### PR TITLE
Add Japanese guide for new participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Streamlit application that extract graph data (entities and relationships) fro
 
 👉 This repo is part of my project tutorial on Youtube:
 [![](https://img.youtube.com/vi/O-T_6KOXML4/0.jpg)](https://www.youtube.com/watch?v=O-T_6KOXML4)
+日本語での概要は [docs/NEW_PARTICIPANT_GUIDE_JA.md](docs/NEW_PARTICIPANT_GUIDE_JA.md) を参照してください。
 
 ## Features
 

--- a/docs/NEW_PARTICIPANT_GUIDE_JA.md
+++ b/docs/NEW_PARTICIPANT_GUIDE_JA.md
@@ -1,0 +1,35 @@
+# リポジトリ概要 (日本語)
+
+このリポジトリは、テキストからエンティティと関係を抽出し、ナレッジグラフを生成して表示する Streamlit アプリケーションです。新規参加者が全体像を素早く理解できるよう、主要なファイル構成と利用手順をまとめます。
+
+## 主なファイル
+
+- **README.md**
+  - プロジェクトの概要や依存パッケージが記載されています。*Features*、*Installation*、*Usage* などの項目で基本的な使い方を確認できます。
+- **app.py**
+  - Streamlit による Web アプリケーションのエントリポイントです。サイドバーからテキストファイルのアップロードまたは直接入力を選び、「Generate Knowledge Graph」ボタンでグラフ生成処理を実行します。
+- **generate_knowledge_graph.py**
+  - LangChain と OpenAI API を用いてエンティティと関係を抽出し、PyVis でナレッジグラフを描画・保存します。
+- **requirements.txt**
+  - 必要な Python パッケージの一覧です。LangChain 系や Streamlit、PyVis、python-dotenv などが含まれます。
+
+## 基本的な使い方
+
+1. Python 環境を用意し、`requirements.txt` を使って依存パッケージをインストールします。
+2. ルートディレクトリに `.env` ファイルを作成し、`OPENAI_API_KEY` を設定します。
+3. `streamlit run app.py` を実行するとアプリが起動します。
+4. ブラウザ (通常は `http://localhost:8501`) でアプリを開き、テキストファイルをアップロードするか直接入力してグラフを生成します。
+
+## ディレクトリ構成例
+
+```
+knowledge-graph-llms/
+├── app.py
+├── generate_knowledge_graph.py
+├── knowledge_graph.html   # 生成されたグラフのサンプル
+├── knowledge_graph.ipynb  # Jupyter ノートブック版
+├── requirements.txt
+└── README.md
+```
+
+まずは上記ファイルを読み、実際にアプリを起動して動作を確認すると、コード全体の流れをつかみやすくなります。


### PR DESCRIPTION
## Summary
- provide NEW_PARTICIPANT_GUIDE_JA.md with a Japanese overview of the codebase
- link to the new guide from README

## Testing
- `python -m py_compile app.py generate_knowledge_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_6843bb62807083308b473a4abdb3cc29