### PR TITLE
Translate UI text to Japanese

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,31 +11,31 @@ st.set_page_config(
     menu_items=None
 )
 
-# Set the title of the app
-st.title("Knowledge Graph From Text")
+# Set the title of the app in Japanese
+st.title("テキストから知識グラフを生成")
 
 # Sidebar section for user input method
-st.sidebar.title("Input document")
+st.sidebar.title("入力ドキュメント")
 input_method = st.sidebar.radio(
-    "Choose an input method:",
-    ["Upload txt", "Input text"],  # Options for uploading a file or manually inputting text
+    "入力方法を選択してください:",
+    ["テキストをアップロード", "テキストを入力"],  # Options for uploading a file or manually inputting text
 )
 
 # Case 1: User chooses to upload a .txt file
 if input_method == "Upload txt":
     # File uploader widget in the sidebar
-    uploaded_file = st.sidebar.file_uploader(label="Upload file", type=["txt"])
+    uploaded_file = st.sidebar.file_uploader(label="ファイルをアップロード", type=["txt"])
     
     if uploaded_file is not None:
         # Read the uploaded file content and decode it as UTF-8 text
         text = uploaded_file.read().decode("utf-8")
  
         # Button to generate the knowledge graph
-        if st.sidebar.button("Generate Knowledge Graph"):
-            with st.spinner("Generating knowledge graph..."):
+        if st.sidebar.button("知識グラフを生成"):
+            with st.spinner("知識グラフを生成しています..."):
                 # Call the function to generate the graph from the text
                 net = generate_knowledge_graph(text)
-                st.success("Knowledge graph generated successfully!")
+                st.success("知識グラフの生成が完了しました！")
                 
                 # Save the graph to an HTML file
                 output_file = "knowledge_graph.html"
@@ -48,14 +48,14 @@ if input_method == "Upload txt":
 # Case 2: User chooses to directly input text
 else:
     # Text area for manual input
-    text = st.sidebar.text_area("Input text", height=300)
+    text = st.sidebar.text_area("テキストを入力してください", height=300)
 
     if text:  # Check if the text area is not empty
-        if st.sidebar.button("Generate Knowledge Graph"):
-            with st.spinner("Generating knowledge graph..."):
+        if st.sidebar.button("知識グラフを生成"):
+            with st.spinner("知識グラフを生成しています..."):
                 # Call the function to generate the graph from the input text
                 net = generate_knowledge_graph(text)
-                st.success("Knowledge graph generated successfully!")
+                st.success("知識グラフの生成が完了しました！")
                 
                 # Save the graph to an HTML file
                 output_file = "knowledge_graph.html"


### PR DESCRIPTION
## Summary
- translate UI labels from English to Japanese
- ensure newline at the end of the file

## Testing
- `python -m py_compile app.py generate_knowledge_graph.py`

------
https://chatgpt.com/codex/tasks/task_e_6843c005e2048330916398f13febe18f