### PR TITLE
Add timestamped output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This will start the application and open it in your default web browser (typical
    - Hover over nodes and edges to see additional information
    - Zoom in/out using the mouse wheel
    - Filter the graph for specific nodes and edges.
+7. The resulting HTML graph is saved in the `out` directory with a timestamped filename.
 
 ## How It Works
 

--- a/docs/NEW_PARTICIPANT_GUIDE_JA.md
+++ b/docs/NEW_PARTICIPANT_GUIDE_JA.md
@@ -26,7 +26,7 @@
 knowledge-graph-llms/
 ├── app.py
 ├── generate_knowledge_graph.py
-├── knowledge_graph.html   # 生成されたグラフのサンプル
+├── out/                   # 生成されたグラフの保存先
 ├── knowledge_graph.ipynb  # Jupyter ノートブック版
 ├── requirements.txt
 └── README.md

--- a/generate_knowledge_graph.py
+++ b/generate_knowledge_graph.py
@@ -6,6 +6,9 @@ from pyvis.network import Network
 from dotenv import load_dotenv
 import os
 import asyncio
+from datetime import datetime
+
+OUTPUT_DIR = "out"
 
 
 # Load the .env file
@@ -99,7 +102,9 @@ def visualize_graph(graph_documents):
         }
     """)
 
-    output_file = "knowledge_graph.html"
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_file = os.path.join(OUTPUT_DIR, f"knowledge_graph_{timestamp}.html")
     try:
         net.save_graph(output_file)
         print(f"Graph saved to {os.path.abspath(output_file)}")


### PR DESCRIPTION
## Summary
- save generated graphs to `out` directory with timestamped names
- document the new output location in the user guide and README
- add `out/.gitkeep` so the folder is tracked

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684403b750088330b2f7b3e6f5b5c4b0