### PR TITLE
Change saved graph naming and dropdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import streamlit as st
 import streamlit.components.v1 as components  # For embedding custom HTML
 from generate_knowledge_graph import generate_knowledge_graph
 import os
+import re
 
 st.set_page_config(
     page_icon=None,
@@ -29,8 +30,17 @@ input_method = st.sidebar.radio(
 )
 
 # Dropdown list of saved graphs
-saved_files = sorted([f for f in os.listdir("out") if f.endswith(".html")])
-selected_saved = st.sidebar.selectbox("保存済みグラフを表示", saved_files) if saved_files else None
+files = [f for f in os.listdir("out") if f.endswith(".html")]
+info_list = []
+for f in files:
+    m = re.match(r"(\d{8}_\d{6})_(.*?)_(.*)\.html$", f)
+    if m:
+        timestamp, summary, model = m.groups()
+        info_list.append((timestamp, summary, model, f))
+info_list.sort(key=lambda x: x[0], reverse=True)
+display_names = [f"{info[1]}_{info[2]}" for info in info_list]
+file_map = {f"{info[1]}_{info[2]}": info[3] for info in info_list}
+selected_display = st.sidebar.selectbox("保存済みグラフを表示", display_names) if display_names else None
 
 generated = False
 
@@ -56,6 +66,6 @@ else:
                     components.html(HtmlFile.read(), height=1000)
                 generated = True
 
-if not generated and selected_saved:
-    with open(os.path.join("out", selected_saved), "r", encoding="utf-8") as HtmlFile:
+if not generated and selected_display:
+    with open(os.path.join("out", file_map[selected_display]), "r", encoding="utf-8") as HtmlFile:
         components.html(HtmlFile.read(), height=1000)

--- a/generate_knowledge_graph.py
+++ b/generate_knowledge_graph.py
@@ -1,6 +1,7 @@
 from langchain_experimental.graph_transformers import LLMGraphTransformer
 from langchain_core.documents import Document
 from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
 from pyvis.network import Network
 
 from dotenv import load_dotenv
@@ -26,7 +27,17 @@ async def extract_graph_data(text, llm):
     return graph_documents
 
 
-def visualize_graph(graph_documents):
+def summarize_text(text, llm, max_chars=25):
+    """Summarize the input text within a character limit using the provided LLM."""
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", f"次のテキストを{max_chars}文字以内で要約してください。"),
+        ("human", "{text}"),
+    ])
+    summary = llm.invoke(prompt.format(text=text)).content.strip().replace("\n", "")
+    return summary[:max_chars]
+
+
+def visualize_graph(graph_documents, output_file):
     """
     Visualizes a knowledge graph using PyVis based on the extracted graph documents.
 
@@ -92,8 +103,6 @@ def visualize_graph(graph_documents):
     """)
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = os.path.join(OUTPUT_DIR, f"knowledge_graph_{timestamp}.html")
     try:
         net.save_graph(output_file)
         print(f"Graph saved to {os.path.abspath(output_file)}")
@@ -119,5 +128,10 @@ def generate_knowledge_graph(text, model_name="gpt-4o-mini"):
     """
     llm = ChatOpenAI(temperature=0, model_name=model_name)
     graph_documents = asyncio.run(extract_graph_data(text, llm))
-    net, output_file = visualize_graph(graph_documents)
+    summary = summarize_text(text, llm)
+    safe_summary = summary.replace(" ", "").replace("_", "").replace("/", "")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{timestamp}_{safe_summary}_{model_name}.html"
+    output_file = os.path.join(OUTPUT_DIR, filename)
+    net, output_file = visualize_graph(graph_documents, output_file)
     return net, output_file


### PR DESCRIPTION
## Summary
- add LLM-based summarization for saved graph filenames
- save graphs as `yyyymmdd_hhmmss_<summary>_<LLM>.html`
- sort saved graphs by timestamp and show `<summary>_<LLM>` in sidebar

## Testing
- `python -m py_compile app.py generate_knowledge_graph.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68443ee0f668833092b4c2392834b4d7