### PR TITLE
Show graph data list above network visualization

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,24 @@ import streamlit.components.v1 as components  # For embedding custom HTML
 from generate_knowledge_graph import generate_knowledge_graph
 import os
 
+
+def build_data_html(nodes, relationships):
+    """Return HTML snippet listing nodes and relationships."""
+    node_items = "".join(
+        [f"<li>{getattr(node, 'id', '')} ({getattr(node, 'type', '')})</li>" for node in nodes]
+    )
+    rel_items = "".join(
+        [
+            f"<li>{getattr(rel.source, 'id', '')} -[{getattr(rel, 'type', '')}]-> {getattr(rel.target, 'id', '')}</li>"
+            for rel in relationships
+        ]
+    )
+    return (
+        "<div style='height:400px; overflow:auto; border:1px solid #ccc; padding:10px;'>"
+        "<h4>Nodes</h4><ul>" + node_items + "</ul>"
+        "<h4>Relationships</h4><ul>" + rel_items + "</ul></div>"
+    )
+
 st.set_page_config(
     page_icon=None,
     layout="wide",
@@ -40,8 +58,11 @@ if input_method == "Upload txt":
         text = uploaded_file.read().decode("utf-8")
         if st.sidebar.button("知識グラフを生成"):
             with st.spinner("知識グラフを生成しています..."):
-                net, output_path = generate_knowledge_graph(text, model_name=selected_model)
+                net, output_path, nodes, relationships = generate_knowledge_graph(
+                    text, model_name=selected_model
+                )
                 st.success("知識グラフの生成が完了しました！")
+                st.markdown(build_data_html(nodes, relationships), unsafe_allow_html=True)
                 with open(output_path, "r", encoding="utf-8") as HtmlFile:
                     components.html(HtmlFile.read(), height=1000)
                 generated = True
@@ -50,8 +71,11 @@ else:
     if text:
         if st.sidebar.button("知識グラフを生成"):
             with st.spinner("知識グラフを生成しています..."):
-                net, output_path = generate_knowledge_graph(text, model_name=selected_model)
+                net, output_path, nodes, relationships = generate_knowledge_graph(
+                    text, model_name=selected_model
+                )
                 st.success("知識グラフの生成が完了しました！")
+                st.markdown(build_data_html(nodes, relationships), unsafe_allow_html=True)
                 with open(output_path, "r", encoding="utf-8") as HtmlFile:
                     components.html(HtmlFile.read(), height=1000)
                 generated = True

--- a/generate_knowledge_graph.py
+++ b/generate_knowledge_graph.py
@@ -34,7 +34,8 @@ def visualize_graph(graph_documents):
         graph_documents (list): A list of GraphDocument objects with nodes and relationships.
 
     Returns:
-        tuple: The visualized network graph object and the path to the saved HTML file.
+        tuple: The visualized network graph object, the path to the saved HTML file,
+        and the extracted nodes and relationships.
     """
     # Create network
     net = Network(height="1200px", width="100%", directed=True,
@@ -120,4 +121,6 @@ def generate_knowledge_graph(text, model_name="gpt-4o-mini"):
     llm = ChatOpenAI(temperature=0, model_name=model_name)
     graph_documents = asyncio.run(extract_graph_data(text, llm))
     net, output_file = visualize_graph(graph_documents)
-    return net, output_file
+    nodes = graph_documents[0].nodes
+    relationships = graph_documents[0].relationships
+    return net, output_file, nodes, relationships


### PR DESCRIPTION
## Summary
- expose nodes and relationships from `generate_knowledge_graph`
- show lists of nodes and relationships above the graph in Streamlit app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68443fd6df00833097aa5a466b3d8528